### PR TITLE
fix: add missing weekdays and dayOfTheWeek properties for Simple Weather compatibility

### DIFF
--- a/src/api/simple-calendar-api.ts
+++ b/src/api/simple-calendar-api.ts
@@ -1947,6 +1947,8 @@ export class SimpleCalendarAPIBridge implements SimpleCalendarAPI {
       hour,
       minute,
       seconds, // Note: 'seconds' not 'second' (Simple Calendar format)
+      weekdays: [], // Empty array when no calendar available
+      dayOfTheWeek: 0, // Default to first day of week
     };
   }
 
@@ -1970,8 +1972,14 @@ export class SimpleCalendarAPIBridge implements SimpleCalendarAPI {
       this.seasonsStars?.api?.formatDate?.(ssDate, { format: '{{month.name}}' }) ||
       `Month ${ssDate.month}`;
 
+    // Get weekday names and calculate day of week for Simple Weather compatibility
+    const weekdayNames = this.seasonsStars?.api?.getWeekdayNames?.() || [];
+    const dayOfTheWeek = ssDate.weekday !== undefined ? ssDate.weekday : 0;
+
     return {
       ...baseDate,
+      weekdays: weekdayNames,
+      dayOfTheWeek: dayOfTheWeek,
       display: {
         monthName,
         day: ssDate.day.toString(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1218,12 +1218,11 @@ Hooks.once('init', () => {
       '🌉 Simple Calendar Compatibility Bridge | Registering fake SC module during init for early detection'
     );
 
-    // Create the fake module entry immediately with all properties Simple Weather might check
-    // IMPORTANT: Must match real Module structure or Foundry's module management UI breaks
-    const fakeModule: any = {
+    // Create a real Foundry Module instance for proper compatibility
+    // IMPORTANT: Must be a real Module instance or Foundry's module management UI breaks
+    const fakeModuleData = {
       id: 'foundryvtt-simple-calendar',
       title: 'Simple Calendar (Compatibility Bridge)',
-      active: true,
       version: FAKE_SIMPLE_CALENDAR_VERSION,
       compatibility: {
         minimum: '13',
@@ -1235,14 +1234,13 @@ Hooks.once('init', () => {
       styles: [],
       languages: [],
       packs: [],
-      packFolders: [], // v13 compendium folders
+      packFolders: [],
       scripts: [],
       relationships: {
         requires: [],
         recommends: [],
         conflicts: [],
         systems: [],
-        flags: {},
       },
       description: 'Compatibility bridge providing Simple Calendar API for modern calendar modules',
       url: '',
@@ -1254,35 +1252,13 @@ Hooks.once('init', () => {
       socket: false,
       download: '',
       manifest: '',
-      // Add toObject method - must return full object for Foundry's module management UI
-      toObject: function () {
-        return {
-          id: this.id,
-          title: this.title,
-          active: this.active,
-          version: this.version,
-          compatibility: this.compatibility,
-          authors: this.authors,
-          esmodules: this.esmodules,
-          styles: this.styles,
-          languages: this.languages,
-          packs: this.packs,
-          packFolders: this.packFolders,
-          scripts: this.scripts,
-          relationships: this.relationships,
-          description: this.description,
-          url: this.url,
-          readme: this.readme,
-          bugs: this.bugs,
-          changelog: this.changelog,
-          flags: this.flags,
-          media: this.media,
-          socket: this.socket,
-          download: this.download,
-          manifest: this.manifest,
-        };
-      },
     };
+
+    // Create actual Module instance using Foundry's constructor
+    const fakeModule = new (globalThis as any).foundry.packages.Module(fakeModuleData);
+
+    // Mark as active since we're providing the compatibility
+    (fakeModule as any).active = true;
 
     // Add to game.modules immediately with error handling
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1254,13 +1254,32 @@ Hooks.once('init', () => {
       socket: false,
       download: '',
       manifest: '',
-      // Add toObject method in case Simple Weather checks it
+      // Add toObject method - must return full object for Foundry's module management UI
       toObject: function () {
         return {
           id: this.id,
           title: this.title,
           active: this.active,
           version: this.version,
+          compatibility: this.compatibility,
+          authors: this.authors,
+          esmodules: this.esmodules,
+          styles: this.styles,
+          languages: this.languages,
+          packs: this.packs,
+          packFolders: this.packFolders,
+          scripts: this.scripts,
+          relationships: this.relationships,
+          description: this.description,
+          url: this.url,
+          readme: this.readme,
+          bugs: this.bugs,
+          changelog: this.changelog,
+          flags: this.flags,
+          media: this.media,
+          socket: this.socket,
+          download: this.download,
+          manifest: this.manifest,
         };
       },
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1252,13 +1252,12 @@ Hooks.once('init', () => {
       socket: false,
       download: '',
       manifest: '',
+      // Module is active since we're providing the compatibility
+      active: true,
     };
 
     // Create actual Module instance using Foundry's constructor
     const fakeModule = new (globalThis as any).foundry.packages.Module(fakeModuleData);
-
-    // Mark as active since we're providing the compatibility
-    (fakeModule as any).active = true;
 
     // Add to game.modules immediately with error handling
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1219,7 +1219,8 @@ Hooks.once('init', () => {
     );
 
     // Create the fake module entry immediately with all properties Simple Weather might check
-    const fakeModule = {
+    // IMPORTANT: Must match real Module structure or Foundry's module management UI breaks
+    const fakeModule: any = {
       id: 'foundryvtt-simple-calendar',
       title: 'Simple Calendar (Compatibility Bridge)',
       active: true,
@@ -1234,19 +1235,25 @@ Hooks.once('init', () => {
       styles: [],
       languages: [],
       packs: [],
+      packFolders: [], // v13 compendium folders
       scripts: [],
       relationships: {
         requires: [],
         recommends: [],
         conflicts: [],
         systems: [],
+        flags: {},
       },
       description: 'Compatibility bridge providing Simple Calendar API for modern calendar modules',
       url: '',
       readme: '',
       bugs: '',
+      changelog: '',
       flags: {},
+      media: [],
       socket: false,
+      download: '',
+      manifest: '',
       // Add toObject method in case Simple Weather checks it
       toObject: function () {
         return {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -47,6 +47,10 @@ export type SimpleCalendarDateTime = SimpleCalendarDate &
       day: string;
       year: string;
     };
+    /** Array of weekday names (required by Simple Weather) */
+    weekdays?: string[];
+    /** Index of the current day of the week (required by Simple Weather) */
+    dayOfTheWeek?: number;
   };
 
 /**

--- a/test/date-methods.test.ts
+++ b/test/date-methods.test.ts
@@ -26,6 +26,8 @@ describe('Simple Calendar API Bridge - Date Methods', () => {
         hour: 0,
         minute: 0,
         seconds: 0,
+        weekdays: [],
+        dayOfTheWeek: 0,
       });
     });
 
@@ -50,7 +52,7 @@ describe('Simple Calendar API Bridge - Date Methods', () => {
           setActiveCalendar: vi.fn(),
           getAvailableCalendars: vi.fn(),
           getMonthNames: vi.fn(),
-          getWeekdayNames: vi.fn(),
+          getWeekdayNames: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
           getActiveCalendar: vi.fn(),
         },
         widgets: {
@@ -81,6 +83,8 @@ describe('Simple Calendar API Bridge - Date Methods', () => {
         hour: 12,
         minute: 30,
         seconds: 45,
+        weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        dayOfTheWeek: 3,
         display: {
           monthName: 'June',
           day: '15',
@@ -136,6 +140,8 @@ describe('Simple Calendar API Bridge - Date Methods', () => {
         hour: 0,
         minute: 0,
         seconds: 0,
+        weekdays: [],
+        dayOfTheWeek: 0,
       });
       expect(consoleSpy).toHaveBeenCalledWith('Failed to get current date:', expect.any(Error));
 

--- a/test/format-conversion.test.ts
+++ b/test/format-conversion.test.ts
@@ -25,6 +25,8 @@ describe('Format Conversion Helpers', () => {
         hour: 0,
         minute: 0,
         seconds: 0,
+        weekdays: [],
+        dayOfTheWeek: 0,
       });
     });
 

--- a/test/timestamp-methods.test.ts
+++ b/test/timestamp-methods.test.ts
@@ -25,6 +25,8 @@ describe('Simple Calendar API Bridge - Timestamp Methods', () => {
         hour: 0,
         minute: 0,
         seconds: 0,
+        weekdays: [],
+        dayOfTheWeek: 0,
       });
     });
 
@@ -49,7 +51,7 @@ describe('Simple Calendar API Bridge - Timestamp Methods', () => {
           setActiveCalendar: vi.fn(),
           getAvailableCalendars: vi.fn(),
           getMonthNames: vi.fn(),
-          getWeekdayNames: vi.fn(),
+          getWeekdayNames: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
           getActiveCalendar: vi.fn(),
         },
         widgets: {
@@ -80,6 +82,8 @@ describe('Simple Calendar API Bridge - Timestamp Methods', () => {
         hour: 12,
         minute: 30,
         seconds: 45,
+        weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        dayOfTheWeek: 3,
         display: {
           monthName: 'June',
           day: '15',
@@ -136,6 +140,8 @@ describe('Simple Calendar API Bridge - Timestamp Methods', () => {
         hour: 0,
         minute: 0,
         seconds: 0,
+        weekdays: [],
+        dayOfTheWeek: 0,
       });
       expect(consoleSpy).toHaveBeenCalledWith(
         '🌉 Failed to convert timestamp to Simple Calendar date:',
@@ -158,6 +164,8 @@ describe('Simple Calendar API Bridge - Timestamp Methods', () => {
         hour: 5,
         minute: 30,
         seconds: 45,
+        weekdays: [],
+        dayOfTheWeek: 0,
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes two critical bugs preventing Simple Weather from rendering and users from opening Foundry's module management screen.

### Bug #1: Simple Weather Rendering Error
**Error**: `Cannot read properties of undefined (reading 'undefined')` at WeatherApplication.ts:160
**Cause**: Missing `weekdays` array and `dayOfTheWeek` index on date objects
**Fix**: Added both properties to `SimpleCalendarDateTime` type and populated them from S&S API

### Bug #2: Module Management Screen Error  
**Error**: `Cannot read properties of undefined (reading 'length')` in ModuleManagement._prepareContext
**Cause**: Fake module object missing properties expected by Foundry v13 module management UI
**Fix**: Enhanced fake module with complete Foundry v13 Module properties (packFolders, changelog, media, download, manifest, etc.)

## Changes

**Type Definitions:**
- Added `weekdays?: string[]` to SimpleCalendarDateTime type
- Added `dayOfTheWeek?: number` to SimpleCalendarDateTime type

**API Implementation:**
- Updated `convertSSToSCDateTime()` to fetch weekday names from S&S and populate weekdays array
- Updated `createFallbackDateTime()` to include empty weekdays array and dayOfTheWeek: 0

**Module Registration:**
- Enhanced fake module object with all Foundry v13 Module properties
- Added detailed comment explaining why complete structure is required

## Test Plan

- [x] Build succeeds with no TypeScript errors
- [ ] Simple Weather renders correctly without errors
- [ ] Module management screen opens without errors  
- [ ] All existing functionality continues to work

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)