### PR TITLE
fix: simple weather button registration timing and module ID

### DIFF
--- a/test/simple-weather-integration.test.ts
+++ b/test/simple-weather-integration.test.ts
@@ -75,7 +75,7 @@ describe('Simple Weather Integration', () => {
         id: 'foundryvtt-simple-calendar',
         title: 'Simple Calendar (Compatibility Bridge)',
         active: true,
-        version: '2.4.18',
+        version: '2.4.18.5',
       };
 
       mockModules.set('foundryvtt-simple-calendar', fakeModule);
@@ -84,7 +84,7 @@ describe('Simple Weather Integration', () => {
       const detectedModule = game.modules.get('foundryvtt-simple-calendar');
       expect(detectedModule).toBeDefined();
       expect(detectedModule.active).toBe(true);
-      expect(detectedModule.version).toBe('2.4.18');
+      expect(detectedModule.version).toBe('2.4.18.5');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes critical issues preventing Simple Weather from registering its sidebar button with the compatibility bridge.

## Root Cause

Simple Weather's Init hook listener was firing before `checkDependencies()` had run, causing `simpleCalendarInstalled` to be `false` when the listener checked it. This prevented the button registration from executing.

## Changes Made

### 1. Hook Timing Fix (Primary Fix)
- Init hook now fires using `queueMicrotask()` after all ready hooks complete
- Guarantees Simple Weather's `checkDependencies()` runs before Init hook fires
- Ensures `simpleCalendarInstalled` flag is set to `true` before Init listener checks it

### 2. Module ID Corrections
- Updated diagnostic code to use correct module ID `'simple-weather'` instead of `'foundryvtt-simple-weather'`
- Fixes module detection in debug logging

### 3. Version Update
- Updated exposed Simple Calendar version to `2.4.18.5`
- Matches Simple Weather's `SC_PREFERRED_VERSION` requirement
- Prevents version mismatch warnings

## Technical Details

**Hook Execution Order:**
1. `setup` hook: Simple Weather registers Init listener
2. `ready` hook (Simple Weather): `checkDependencies()` sets `simpleCalendarInstalled = true`
3. `ready` hook (bridge): Uses `queueMicrotask()` to defer Init emission
4. After all ready hooks: Init fires → listener runs → `simpleCalendarInstalled` is `true` → button registers ✅

## Testing

- [x] Simple Weather button appears on Seasons & Stars calendar widgets
- [x] No version mismatch warnings
- [x] Module detection works correctly
- [x] Console logs confirm proper timing

## Files Changed

- `src/main.ts`: Hook timing fix, module ID corrections, version update
- `test/simple-weather-integration.test.ts`: Updated version expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)